### PR TITLE
Run second exection via ApplyUpdate similar to previous run model

### DIFF
--- a/src/Engine/ProtoScript/Runners/LiveRunner.cs
+++ b/src/Engine/ProtoScript/Runners/LiveRunner.cs
@@ -1507,19 +1507,15 @@ namespace ProtoScript.Runners
 
         private bool CompileAndExecute(List<AssociativeNode> astList)
         {
-            bool succeeded;
-            if (!astList.Any())
-            {
-                succeeded = true;
-            }
-            else
+            bool succeeded = false;
+            if (astList.Any())
             {
                 succeeded = Compile(astList, runnerCore);
             }
+
             if (succeeded)
             {
-                //Execute(astList.Count > 0);
-                Execute(succeeded);
+                Execute(astList.Count > 0);
             }
             return succeeded;
         }


### PR DESCRIPTION
This change update the management of the runs to be much more similar to the non-optimized runs.  The Execute() call is reserved for actual changes involving additive AST's.  Otherwise the Apply update will rerun the graph and exit without error